### PR TITLE
Fix running GHA on pushes and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ name: CI
 
 on:
   pull_request:
-    branches: [devel]
+    branches: [main]
 
   push:
-    branches: [devel]
+    branches: [main]
 
 jobs:
   podman:


### PR DESCRIPTION
This change makes sure to use proper main branch in the CI workflow
trigger filters.